### PR TITLE
tag compute

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ version = '1.7.0'
 allprojects {
     repositories {
         jcenter()
-        maven { url "https://jitpack.io" }
+        maven { url "http://tag-compute.inf.sussex.ac.uk/mvn/release" }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ version = '1.7.0'
 allprojects {
     repositories {
         jcenter()
-        maven { url "http://tag-compute.inf.sussex.ac.uk/mvn/release" }
+        maven { url "url to deploy" }
     }
 }
 


### PR DESCRIPTION
I know that he publishes maven to `jitpack.io`, because I've used that dependency. So I replaced that with a url to our release repo.

There are references to maven central, but I'm pretty sure he doesn't publish there, so that must be for dependencies. 

Be aware that there are 4 subprojects that all have their own build script, and one root build script. I've confirmed that our way of adding the maven-publish plugin is legit (its an older more flexible method).

I think that's all we need. Try a `./gradew publish`. I think that should fire all publish tasks. Otherwise we might need the `publishPubNamePublicationToRepoNameRepository` task (see https://docs.gradle.org/current/userguide/publishing_maven.html)

He doesn't declare a "publications" block, so we should try without first.
Otherwise might need something like the following the build script:
```
publishing {
        publications {
            create<MavenPublication>("maven") {
                groupId = "org.gradle.sample"
                artifactId = "project1-sample"
                version = "1.1"

                from(components["java"])
            }
        }
    }
```

I hope we don't have to fiddle with the 4 nested build scripts, but I could see having to maybe declare our repo in those too. 